### PR TITLE
fix Error: Cannot find module './client'

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,4 +18,4 @@ exports.Connection = require("./lib/connection");
 exports.Lob = require("./lib/lob");
 exports.SDB = require("./lib/const");
 exports.Long = require("long");
-exports.Client = require('./client');
+exports.Client = require('./lib/client');


### PR DESCRIPTION
To fix the error we got from  the command line as below:

// win10
C:\Users\shanks>node

var Client =require('sequoiadb').Client
Error: Cannot find module './client'
at Function.Module._resolveFilename (module.js:325:15)
at Function.Module._load (module.js:276:25)
at Module.require (module.js:353:17)
at require (internal/module.js:12:17)
at Object. (C:\Users\shanks\node_modules\sequoiadb\index.js:21:18)
at Module._compile (module.js:409:26)
at Object.Module._extensions..js (module.js:416:10)
at Module.load (module.js:343:32)
at Function.Module._load (module.js:300:12)
at Module.require (module.js:353:17)

// ubuntu1804

var Client = require('sequoiadb').Client;
Thrown:
{ Error: Cannot find module './client'
at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
at Function.Module._load (internal/modules/cjs/loader.js:562:25)
at Module.require (internal/modules/cjs/loader.js:692:17)
at require (internal/modules/cjs/helpers.js:25:18) code: 'MODULE_NOT_FOUND' }